### PR TITLE
fix: remove debug output printed to console

### DIFF
--- a/src/main/java/teamroots/emberroot/entity/knight/EntityFallenKnight.java
+++ b/src/main/java/teamroots/emberroot/entity/knight/EntityFallenKnight.java
@@ -102,7 +102,7 @@ public class EntityFallenKnight extends EntitySkeleton {
     }
     firstUpdate = false;
     if (!isMounted == isRidingMount()) {
-      System.out.println("attack on collide reset");
+      //      System.out.println("attack on collide reset");
       getAiAttackOnCollide().resetTask();
       //      getAiArrowAttack().resetTask();
       getNavigator().clearPathEntity();


### PR DESCRIPTION
I chose to comment out the line instead of removing it as it appears other instances were commented instead as well.

Fixes #37 